### PR TITLE
fix: enable ttl on AllTypes model and add ttl field

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -2,7 +2,7 @@ import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource';
 import { myDemoFunction } from './functions/my-demo-function/resource'
 import { storage } from './storage/resource.js';
-import { data } from './data/resource.js';
+import { TTL_ATTRIBUTE_NAME, data } from './data/resource.js';
 
 
 const backend = defineBackend({
@@ -27,3 +27,10 @@ backend.storage.resources.bucket.grantReadWrite(authRole);
 const unauthRole = backend.auth.resources.unauthenticatedUserIamRole;
 backend.storage.resources.bucket.grantRead(unauthRole);
 //bucket.grantRead(unauthRole);
+
+// enable TTL on data table
+const dataResources = backend.data.resources;
+dataResources.cfnResources.amplifyDynamoDbTables['AllTypes'].timeToLiveAttribute = {
+  enabled: true,
+  attributeName: TTL_ATTRIBUTE_NAME,
+};

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -2,6 +2,8 @@
 
 import { a, defineData, type ClientSchema } from '@aws-amplify/backend';
 
+export const TTL_ATTRIBUTE_NAME = 'ttl';
+
 const schema = a.schema({
   Todo: a
     .model({
@@ -44,6 +46,7 @@ const schema = a.schema({
         ipAddress: a.ipAddress(),
       }),
       enum: a.enum(['some', 'enum', 'value']),
+      [TTL_ATTRIBUTE_NAME]: a.timestamp(),
     })
     .authorization((allow) => [
       allow.publicApiKey(),


### PR DESCRIPTION
The number of records in the AllTypes table slowly grows, unbound, when an e2e test fails. This PR adds a ttl property that will hold a time for DDB to automatically delete the record if it still exists in the table, as well as enabling the ttl functionality itself.

Ideally this would be accompanied with a custom resolver or other backend mechanism to automatically set the ttl, but this does not seem to be a simple task. Instead, an update to the e2e tests will be made to set the ttl field via the create/update forms in DataManager, and a backend-only solution can be revisited at a later time.